### PR TITLE
Reduce default UI scale to match Windows sizing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -117,7 +117,7 @@ const AppContent: React.FC = () => {
   const [pendingToolCalls, setPendingToolCalls] = useState<ToolCall[] | null>(null);
   const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
-  const [sidebarWidth, setSidebarWidth] = useState(256);
+  const [sidebarWidth, setSidebarWidth] = useState(205); // 20% reduction from the previous 256px default
   const isResizingRef = useRef(false);
   const { addToast } = useToast();
   const [isMaximized, setIsMaximized] = useState(false);

--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@
     <title>Local LLM Interface</title>
     <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
     <style>
+      html {
+        font-size: 80%; /* Reduce overall rem-based sizing by 20% to align with Windows scaling */
+      }
+
       :root {
         --bg-primary: #ffffff;
         --bg-secondary: #f8fafc;
@@ -44,7 +48,7 @@
         --assistant-message-bg-color: var(--bg-tertiary);
         --assistant-message-text-color: var(--text-primary);
         --chat-font-family: sans-serif;
-        --chat-font-size: 16px;
+        --chat-font-size: calc(16px * 0.8); /* Keep chat text aligned with the reduced global scale */
 
         /* Density & Scale Variables */
         --font-size-sm: 0.875rem;


### PR DESCRIPTION
## Summary
- reduce the global rem scale by setting the root font size to 80% and align chat typography with the new baseline
- shrink the default sidebar width by roughly twenty percent to maintain proportional layout with the smaller controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd5073950083328a8ec9931d557baf