### PR TITLE
Unify application tooltips with modern styling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -23,6 +23,7 @@ import { runPythonCode } from './services/pyodideService';
 import { ToastProvider, ToastContainer } from './components/ToastProvider';
 import { useToast } from './hooks/useToast';
 import TitleBar from './components/TitleBar';
+import { useTooltipTrigger } from './hooks/useTooltipTrigger';
 
 type View = 'chat' | 'projects' | 'api' | 'settings' | 'info';
 
@@ -35,11 +36,12 @@ const NavButton: React.FC<{
   title: string;
 }> = ({ active, onClick, children, ariaLabel, view, title }) => {
     const accentVar = `var(--accent-${view})`;
+    const tooltipProps = useTooltipTrigger(title);
     return (
         <button
             onClick={onClick}
-            title={title}
             aria-label={ariaLabel}
+            {...tooltipProps}
             className={`relative flex items-center gap-[var(--space-2)] px-[var(--space-4)] py-[var(--space-2)] text-[length:var(--font-size-sm)] font-medium rounded-lg transition-colors duration-200 ${
                 active
                     ? `text-[--accent-${view}]`
@@ -118,6 +120,8 @@ const AppContent: React.FC = () => {
   const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState(205); // 20% reduction from the previous 256px default
+
+  const toggleLogsTooltip = useTooltipTrigger('Toggle the application logs panel for debugging');
   const isResizingRef = useRef(false);
   const { addToast } = useToast();
   const [isMaximized, setIsMaximized] = useState(false);
@@ -1280,7 +1284,7 @@ const AppContent: React.FC = () => {
                   onClick={() => setIsLogPanelVisible(!isLogPanelVisible)}
                   className="p-2 rounded-full text-[--text-muted] hover:bg-[--bg-hover] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[--bg-primary] focus:ring-[--border-focus]"
                   aria-label="Toggle logs panel"
-                  title="Toggle the application logs panel for debugging"
+                  {...toggleLogsTooltip}
                   >
                   <Icon name="fileText" className="w-5 h-5" />
                   </button>

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -57,6 +57,19 @@ const ContextSources: React.FC<{ files: string[] }> = ({ files }) => {
     );
 };
 
+const PredefinedPromptButton: React.FC<{ prompt: PredefinedPrompt; onSelect: (content: string) => void; }> = ({ prompt, onSelect }) => {
+    const tooltipProps = useTooltipTrigger(prompt.content);
+    return (
+        <button
+            {...tooltipProps}
+            onClick={() => onSelect(prompt.content)}
+            className="w-full text-left block px-3 py-1.5 text-sm text-[--text-secondary] hover:bg-[--bg-hover] hover:text-[--text-primary] truncate"
+        >
+            {prompt.title}
+        </button>
+    );
+};
+
 const MessageMetadata: React.FC<{ metadata: ChatMessageMetadata }> = ({ metadata }) => {
     const { usage, speed } = metadata;
 
@@ -784,14 +797,11 @@ export default function ChatView({ session, provider, onSendMessage, isRespondin
                               <div className="p-2 text-xs font-semibold text-[--text-muted] border-b border-[--border-primary]">Saved Prompts</div>
                               {predefinedPrompts.length > 0 ? (
                                   predefinedPrompts.map(p => (
-                                      <button 
+                                      <PredefinedPromptButton
                                           key={p.id}
-                                          onClick={() => handleSelectPrompt(p.content)}
-                                          title={p.content}
-                                          className="w-full text-left block px-3 py-1.5 text-sm text-[--text-secondary] hover:bg-[--bg-hover] hover:text-[--text-primary] truncate"
-                                      >
-                                          {p.title}
-                                      </button>
+                                          prompt={p}
+                                          onSelect={handleSelectPrompt}
+                                      />
                                   ))
                               ) : (
                                   <p className="p-3 text-sm text-center text-[--text-muted]">No prompts saved yet. Add some in Settings.</p>

--- a/components/ProjectsView.tsx
+++ b/components/ProjectsView.tsx
@@ -136,6 +136,7 @@ const ProjectCard: React.FC<{
     const openFolderTooltip = useTooltipTrigger("Open project folder in your file explorer");
     const deleteTooltip = useTooltipTrigger("Permanently delete this project and all its files. This action cannot be undone.");
     const expandTooltip = useTooltipTrigger(isExpanded ? "Collapse file explorer" : "Expand file explorer");
+    const pathTooltip = useTooltipTrigger(project.path);
 
     return (
         <div className={`bg-[--bg-primary] rounded-[--border-radius] border border-[--border-primary] flex flex-col transition-all duration-200 ${isExpanded ? 'shadow-xl ring-2 ring-[--accent-projects]/50' : 'hover:shadow-md'}`}>
@@ -150,7 +151,12 @@ const ProjectCard: React.FC<{
                     </div>
                 </div>
                 
-                <p className="text-xs text-[--text-muted] font-mono break-all h-8 overflow-hidden" title={project.path}>{project.path}</p>
+                <p
+                    className="text-xs text-[--text-muted] font-mono break-all h-8 overflow-hidden"
+                    {...pathTooltip}
+                >
+                    {project.path}
+                </p>
             
                 <div className="grid grid-cols-2 gap-2 mt-4">
                      <button {...chatTooltip} onClick={onChat} disabled={isBusy} className="col-span-2 text-sm px-4 py-2 rounded-lg bg-[--accent-projects] text-white hover:brightness-95 disabled:opacity-60 disabled:cursor-wait flex items-center justify-center gap-2 font-semibold">

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -212,7 +212,7 @@ const ToolchainSelector: React.FC<{
           <option value="default">System Default (from PATH)</option>
           {toolchains.length > 0 && <option disabled>--- Detected ---</option>}
           {toolchains.map(tool => (
-            <option key={tool.path} value={tool.path} title={tool.path}>
+            <option key={tool.path} value={tool.path}>
               {tool.name} ({tool.path})
             </option>
           ))}

--- a/components/StatusBar.tsx
+++ b/components/StatusBar.tsx
@@ -49,10 +49,11 @@ const StatusBar: React.FC<StatusBarProps> = ({ stats, connectionStatus, statusTe
     
     const providerTooltip = useTooltipTrigger(statusText);
     const modelTooltip = useTooltipTrigger("Select a model to start a new chat");
-    const projectTooltip = useTooltipTrigger(`Active Project Context: ${activeProject}`);
+    const projectTooltip = useTooltipTrigger(activeProject ? `Active Project Context: ${activeProject}` : 'Active Project Context');
     const cpuTooltip = useTooltipTrigger("System-wide CPU Usage");
     const gpuTooltip = useTooltipTrigger(stats?.gpu !== undefined && stats.gpu >= 0 ? `System-wide GPU Usage: ${stats.gpu.toFixed(0)}%` : "System-wide GPU Usage (N/A or Requires NVIDIA GPU)");
     const ramTooltip = useTooltipTrigger("System-wide RAM Usage");
+    const versionTooltip = useTooltipTrigger(version ? `Application Version ${version}` : 'Application Version');
 
 
     useEffect(() => {
@@ -189,7 +190,7 @@ const StatusBar: React.FC<StatusBarProps> = ({ stats, connectionStatus, statusTe
                 {version && (
                     <>
                         <div className="w-px h-4 bg-[--border-primary]" />
-                        <span title={`Application Version ${version}`}>v{version}</span>
+                        <span {...versionTooltip}>v{version}</span>
                     </>
                 )}
             </div>

--- a/components/TitleBar.tsx
+++ b/components/TitleBar.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import Icon from './Icon';
 import ThemeSwitcher from './ThemeSwitcher';
 import type { Theme } from '../types';
+import { useTooltipTrigger } from '../hooks/useTooltipTrigger';
 
 type View = 'chat' | 'projects' | 'api' | 'settings' | 'info';
 
@@ -12,10 +13,12 @@ const TitleBarNavButton: React.FC<{
     view: View;
     title: string;
 }> = ({ active, onClick, children, view, title }) => {
+    const tooltipProps = useTooltipTrigger(title);
     return (
         <button
             onClick={onClick}
-            title={title}
+            aria-label={title}
+            {...tooltipProps}
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
             className={`relative flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md transition-colors duration-200 ${
                 active
@@ -41,6 +44,7 @@ interface TitleBarProps {
 
 const TitleBar: React.FC<TitleBarProps> = ({ activeView, onNavigate, onToggleLogs, onToggleTheme, theme, onOpenCommandPalette, isMaximized }) => {
     const searchBoxRef = useRef<HTMLDivElement>(null);
+    const logsTooltip = useTooltipTrigger('Toggle logs panel');
 
     const handleMinimize = () => window.electronAPI?.minimizeWindow();
     const handleMaximize = () => isMaximized ? window.electronAPI?.unmaximizeWindow() : window.electronAPI?.maximizeWindow();
@@ -105,7 +109,7 @@ const TitleBar: React.FC<TitleBarProps> = ({ activeView, onNavigate, onToggleLog
                         onClick={onToggleLogs}
                         className="p-2 rounded-full text-[--text-muted] hover:bg-[--bg-hover]"
                         aria-label="Toggle logs panel"
-                        title="Toggle Logs"
+                        {...logsTooltip}
                     >
                         <Icon name="fileText" className="w-4 h-4" />
                     </button>

--- a/components/TooltipProvider.tsx
+++ b/components/TooltipProvider.tsx
@@ -94,20 +94,23 @@ const TooltipComponent: React.FC<{ tooltipState: TooltipState }> = ({ tooltipSta
         }
     }, [tooltipState]);
 
+    const visibilityClass =
+        tooltipState.visible && position.top > -9999
+            ? 'opacity-100 translate-y-0 scale-100'
+            : 'opacity-0 translate-y-1 scale-95';
+
     return (
         <div
             ref={tooltipRef}
-            className={`fixed z-[100] max-w-xs px-3 py-1.5 text-sm font-medium text-white bg-gray-900 rounded-md shadow-lg dark:bg-slate-900/90 dark:border dark:border-slate-700 backdrop-blur-sm transition-opacity duration-200 ${
-                tooltipState.visible && position.top > -9999 ? 'opacity-100' : 'opacity-0'
-            }`}
-            style={{ 
-                top: `${position.top}px`, 
+            className={`fixed z-[100] max-w-xs px-3 py-2 text-sm font-medium text-white bg-slate-950/95 dark:bg-slate-900/95 border border-white/10 dark:border-white/5 rounded-lg shadow-2xl backdrop-blur-md transform-gpu transition-all duration-200 ease-out ${visibilityClass}`}
+            style={{
+                top: `${position.top}px`,
                 left: `${position.left}px`,
                 pointerEvents: 'none',
             }}
             role="tooltip"
         >
-            {tooltipState.content}
+            <span className="block text-left leading-snug tracking-wide">{tooltipState.content}</span>
         </div>
     );
 };

--- a/hooks/useTooltipTrigger.ts
+++ b/hooks/useTooltipTrigger.ts
@@ -4,6 +4,8 @@ import { useTooltip } from '../components/TooltipProvider';
 interface TooltipTriggerProps {
     onMouseEnter: (e: React.MouseEvent<HTMLElement>) => void;
     onMouseLeave: () => void;
+    onFocus: (e: React.FocusEvent<HTMLElement>) => void;
+    onBlur: () => void;
     'aria-label'?: string;
 }
 
@@ -20,16 +22,28 @@ export const useTooltipTrigger = (content: React.ReactNode): Partial<TooltipTrig
         hide();
     }, [hide]);
 
+    const onFocus = useCallback((e: React.FocusEvent<HTMLElement>) => {
+        if (content) {
+            show(content, e.currentTarget.getBoundingClientRect());
+        }
+    }, [show, content]);
+
+    const onBlur = useCallback(() => {
+        hide();
+    }, [hide]);
+
     if (!content) {
         return {};
     }
-    
+
     // Provide an aria-label for accessibility if the content is a simple string.
     const ariaLabel = typeof content === 'string' ? content : undefined;
 
     return {
         onMouseEnter,
         onMouseLeave,
+        onFocus,
+        onBlur,
         'aria-label': ariaLabel,
     };
 };


### PR DESCRIPTION
## Summary
- restyle the global tooltip component with a polished theme and smooth animation
- replace native title attributes with tooltip triggers across navigation, status, and project views
- add reusable helpers for prompt entries and keyboard-focus support so hints remain accessible and unclipped

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd5318e864833291d8754796caec3f