### PR TITLE
Fix tooltip provider context hierarchy

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1215,7 +1215,6 @@ const AppContent: React.FC = () => {
 
   return (
     <IconProvider iconSet={config?.themeOverrides?.iconSet || 'default'}>
-      <TooltipProvider>
         <div style={containerStyle} className="flex flex-col font-sans bg-[--bg-primary] h-screen overflow-hidden text-[--text-primary]">
           {config && <CommandPalette 
             isOpen={isCommandPaletteOpen}
@@ -1335,15 +1334,16 @@ const AppContent: React.FC = () => {
               />
           )}
         </div>
-        <ToastContainer />
-      </TooltipProvider>
     </IconProvider>
   );
 };
 
 const App: React.FC = () => (
   <ToastProvider>
-    <AppContent />
+    <TooltipProvider>
+      <AppContent />
+      <ToastContainer />
+    </TooltipProvider>
   </ToastProvider>
 );
 


### PR DESCRIPTION
## Summary
- wrap the application tree with TooltipProvider at the App level so tooltip hooks have access to context
- keep the toast container mounted within the provider while simplifying AppContent's JSX

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd55f620588332869e1dc26a96d65e