### PR TITLE
Implement customizable keyboard shortcut editor

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -160,6 +160,20 @@ const AppContent: React.FC = () => {
     setView('settings');
   }, []);
 
+  const handleThemeToggle = useCallback(() => {
+    setConfig(currentConfig => {
+      if (!currentConfig) return null;
+      const newTheme = currentConfig.theme === 'light' ? 'dark' : 'light';
+      logger.info(`Theme toggled to ${newTheme}.`);
+      return { ...currentConfig, theme: newTheme };
+    });
+  }, []);
+
+  const handleNewChat = useCallback(() => {
+    setConfig(c => (c ? { ...c, activeSessionId: undefined } : null));
+    setView('chat');
+  }, []);
+
   const performShortcutAction = useCallback((actionId: ShortcutActionId) => {
     switch (actionId) {
       case 'toggleCommandPalette':
@@ -579,15 +593,6 @@ const AppContent: React.FC = () => {
     });
   }, []);
 
-  const handleThemeToggle = () => {
-      setConfig(currentConfig => {
-        if (!currentConfig) return null;
-        const newTheme = currentConfig.theme === 'light' ? 'dark' : 'light';
-        logger.info(`Theme toggled to ${newTheme}.`);
-        return { ...currentConfig, theme: newTheme };
-      });
-  };
-
   const loadModels = useCallback(async () => {
     if (!activeProvider || !config) {
         setError("Provider configuration not loaded. Please select a provider in Settings.");
@@ -617,11 +622,6 @@ const AppContent: React.FC = () => {
   
   const handleSelectSession = (sessionId: string) => {
     setConfig(c => c ? ({ ...c, activeSessionId: sessionId }) : null);
-    setView('chat');
-  };
-
-  const handleNewChat = () => {
-    setConfig(c => c ? ({ ...c, activeSessionId: undefined }) : null);
     setView('chat');
   };
 

--- a/components/ChatView.tsx
+++ b/components/ChatView.tsx
@@ -245,6 +245,7 @@ interface ChatViewProps {
   onSetSessionGenerationConfig: (generationConfig: GenerationConfig) => void;
   onSetSessionAgentToolsEnabled: (enabled: boolean) => void;
   onRunCodeSnippet: (language: string, code: string) => void;
+  onRegisterInputFocusHandler?: (handler: (() => void) | null) => void;
 }
 
 const PersonaSelectorItem: React.FC<{
@@ -264,7 +265,7 @@ const PersonaSelectorItem: React.FC<{
   );
 };
 
-export default function ChatView({ session, provider, onSendMessage, isResponding, retrievalStatus, onStopGeneration, onRenameSession, theme, isElectron, projects, predefinedInput, onPrefillConsumed, models, onSelectModel, predefinedPrompts, systemPrompts, onSetSessionSystemPrompt, onSetSessionGenerationConfig, onSetSessionAgentToolsEnabled, onRunCodeSnippet }: ChatViewProps) {
+export default function ChatView({ session, provider, onSendMessage, isResponding, retrievalStatus, onStopGeneration, onRenameSession, theme, isElectron, projects, predefinedInput, onPrefillConsumed, models, onSelectModel, predefinedPrompts, systemPrompts, onSetSessionSystemPrompt, onSetSessionGenerationConfig, onSetSessionAgentToolsEnabled, onRunCodeSnippet, onRegisterInputFocusHandler }: ChatViewProps) {
   const [input, setInput] = useState('');
   const [attachedImage, setAttachedImage] = useState<string | null>(null);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
@@ -308,6 +309,15 @@ export default function ChatView({ session, provider, onSendMessage, isRespondin
   useEffect(() => {
     setEditedTitle(sessionName);
   }, [sessionName]);
+
+  useEffect(() => {
+    if (!onRegisterInputFocusHandler) return;
+    const handler = () => textareaRef.current?.focus();
+    onRegisterInputFocusHandler(handler);
+    return () => {
+      onRegisterInputFocusHandler(null);
+    };
+  }, [onRegisterInputFocusHandler]);
 
 // FIX: This hook resets component state when switching sessions.
 // This prevents carrying over state like input text or attachments between different conversations.

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -23,9 +23,10 @@ interface CommandPaletteProps {
     onSelectSession: (sessionId: string) => void;
     onOpenFile: (file: { path: string, name: string }) => void;
     anchorRect: DOMRect | null;
+    onShowKeyboardShortcuts: () => void;
 }
 
-const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose, sessions, projects, onNavigate, onSelectSession, onOpenFile, anchorRect }) => {
+const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose, sessions, projects, onNavigate, onSelectSession, onOpenFile, anchorRect, onShowKeyboardShortcuts }) => {
     const [searchTerm, setSearchTerm] = useState('');
     const [commands, setCommands] = useState<Command[]>([]);
     const [isLoadingFiles, setIsLoadingFiles] = useState(false);
@@ -44,6 +45,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose, sessio
                 { type: 'view', id: 'view_projects', name: 'Go to Projects', icon: <Icon name="code" className="w-4 h-4"/>, action: () => onNavigate('projects') },
                 { type: 'view', id: 'view_api', name: 'Go to API Client', icon: <Icon name="server" className="w-4 h-4"/>, action: () => onNavigate('api') },
                 { type: 'view', id: 'view_settings', name: 'Go to Settings', icon: <Icon name="settings" className="w-4 h-4"/>, action: () => onNavigate('settings') },
+                { type: 'view', id: 'view_settings_shortcuts', name: 'Open Keyboard Shortcuts', description: 'Customize keyboard shortcuts', icon: <Icon name="terminal" className="w-4 h-4"/>, action: () => onShowKeyboardShortcuts() },
                 { type: 'view', id: 'view_info', name: 'Go to Info', icon: <Icon name="info" className="w-4 h-4"/>, action: () => onNavigate('info') },
             ];
             
@@ -89,7 +91,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose, sessio
         } else {
             setSearchTerm('');
         }
-    }, [isOpen, sessions, projects, onNavigate, onSelectSession, onOpenFile]);
+    }, [isOpen, sessions, projects, onNavigate, onSelectSession, onOpenFile, onShowKeyboardShortcuts]);
 
     const filteredCommands = useMemo(() => {
         if (!searchTerm) return commands;

--- a/components/KeyboardShortcutsEditor.tsx
+++ b/components/KeyboardShortcutsEditor.tsx
@@ -1,0 +1,370 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ShortcutActionDefinition, ShortcutActionId, ShortcutScope, ShortcutSettings } from '../types';
+import {
+  SHORTCUT_CATEGORY_LABELS,
+  SHORTCUT_CATEGORY_ORDER,
+  SHORTCUT_DEFINITION_MAP,
+  SHORTCUT_DEFINITIONS,
+  cloneShortcutSettings,
+  eventToShortcut,
+  findShortcutConflicts,
+  formatShortcut,
+  getDefaultAssignment,
+  shortcutMatchesSearch,
+} from '../shortcuts';
+import Icon from './Icon';
+
+interface KeyboardShortcutsEditorProps {
+  shortcuts: ShortcutSettings;
+  onShortcutsChange: (shortcuts: ShortcutSettings) => void;
+  onRestoreDefaults: () => void;
+  isElectron: boolean;
+}
+
+const ShortcutButton: React.FC<{
+  label: string;
+  value: string | null;
+  onClick: () => void;
+  onClear: () => void;
+  isCapturing: boolean;
+  conflict?: boolean;
+  disabled?: boolean;
+}> = ({ label, value, onClick, onClear, isCapturing, conflict, disabled }) => {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium uppercase tracking-wide text-[--text-muted]">{label}</span>
+        <button
+          type="button"
+          onClick={onClear}
+          disabled={disabled}
+          className={`text-xs font-medium transition-colors ${
+            disabled ? 'text-[--text-muted] cursor-not-allowed' : 'text-[--accent-settings] hover:text-[--text-primary]'
+          }`}
+        >
+          Clear
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={disabled ? undefined : onClick}
+        disabled={disabled}
+        className={`w-full px-4 py-2 rounded-lg border transition-all text-sm font-medium text-left ${
+          disabled
+            ? 'bg-[--bg-tertiary] text-[--text-muted] border-transparent cursor-not-allowed'
+            : isCapturing
+            ? 'border-[--border-focus] ring-2 ring-[--border-focus] bg-[--bg-tertiary] text-[--text-primary]'
+            : conflict
+            ? 'border-red-500/70 bg-red-500/10 text-red-200 hover:border-red-400'
+            : 'border-[--border-secondary] bg-[--bg-tertiary] hover:border-[--border-focus] text-[--text-primary]'
+        }`}
+      >
+        {isCapturing ? 'Press new shortcut…' : formatShortcut(value)}
+      </button>
+    </div>
+  );
+};
+
+const ShortcutHeader: React.FC<{
+  category: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+}> = ({ category, isExpanded, onToggle }) => (
+  <button
+    type="button"
+    onClick={onToggle}
+    className="w-full flex items-center justify-between px-4 py-3 text-left bg-[--bg-secondary] border-b border-[--border-primary] rounded-t-[--border-radius]"
+  >
+    <div className="flex items-center gap-3 text-[--text-secondary] font-semibold">
+      <Icon name={isExpanded ? 'chevronUp' : 'chevronDown'} className="w-4 h-4" />
+      <span>{category}</span>
+    </div>
+    <span className="text-xs font-medium text-[--text-muted]">{isExpanded ? 'Hide' : 'Show'} actions</span>
+  </button>
+);
+
+const ConflictMessage: React.FC<{ scopeLabel: string; conflicts: ShortcutActionId[] }> = ({ scopeLabel, conflicts }) => (
+  <p className="text-xs text-red-300">
+    {scopeLabel} conflict with {conflicts.map(id => SHORTCUT_DEFINITION_MAP[id]?.label || id).join(', ')}
+  </p>
+);
+
+const KeyboardShortcutsEditor: React.FC<KeyboardShortcutsEditorProps> = ({ shortcuts, onShortcutsChange, onRestoreDefaults, isElectron }) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [expandedCategories, setExpandedCategories] = useState<Record<string, boolean>>(() => {
+    const initial: Record<string, boolean> = {};
+    SHORTCUT_DEFINITIONS.forEach(def => {
+      if (!(def.category in initial)) {
+        initial[def.category] = true;
+      }
+    });
+    return initial;
+  });
+  const [capturing, setCapturing] = useState<{ actionId: ShortcutActionId; scope: ShortcutScope } | null>(null);
+  const [captureError, setCaptureError] = useState<string | null>(null);
+
+  const appConflicts = useMemo(() => findShortcutConflicts(shortcuts, 'app'), [shortcuts]);
+  const globalConflicts = useMemo(() => findShortcutConflicts(shortcuts, 'global'), [shortcuts]);
+
+  const filteredDefinitions = useMemo(() => {
+    return SHORTCUT_DEFINITIONS.filter(def => shortcutMatchesSearch(def, shortcuts[def.id], searchTerm));
+  }, [searchTerm, shortcuts]);
+
+  const groupedDefinitions = useMemo(() => {
+    const groups = new Map<string, ShortcutActionDefinition[]>();
+    filteredDefinitions.forEach(def => {
+      const defs = groups.get(def.category) || [];
+      defs.push(def);
+      groups.set(def.category, defs);
+    });
+    return Array.from(groups.entries())
+      .sort((a, b) => (SHORTCUT_CATEGORY_ORDER[a[0]] || 0) - (SHORTCUT_CATEGORY_ORDER[b[0]] || 0))
+      .map(([category, defs]) => ({
+        category,
+        definitions: defs.sort((a, b) => a.order - b.order),
+      }));
+  }, [filteredDefinitions]);
+
+  const handleToggleCategory = useCallback((category: string) => {
+    setExpandedCategories(prev => ({ ...prev, [category]: !prev[category] }));
+  }, []);
+
+  const handleCaptureStart = useCallback((actionId: ShortcutActionId, scope: ShortcutScope) => {
+    setCapturing({ actionId, scope });
+    setCaptureError(null);
+  }, []);
+
+  const updateShortcuts = useCallback(
+    (updater: (draft: ShortcutSettings) => void) => {
+      const cloned = cloneShortcutSettings(shortcuts);
+      updater(cloned);
+      onShortcutsChange(cloned);
+    },
+    [shortcuts, onShortcutsChange],
+  );
+
+  const handleClearShortcut = useCallback(
+    (actionId: ShortcutActionId, scope: ShortcutScope) => {
+      updateShortcuts(draft => {
+        const entry = draft[actionId];
+        if (scope === 'app') {
+          entry.app = null;
+        } else {
+          entry.global = {
+            ...(entry.global || { key: null, enabled: false }),
+            key: null,
+          };
+        }
+      });
+    },
+    [updateShortcuts],
+  );
+
+  const handleResetAction = useCallback(
+    (actionId: ShortcutActionId) => {
+      updateShortcuts(draft => {
+        draft[actionId] = getDefaultAssignment(actionId);
+      });
+    },
+    [updateShortcuts],
+  );
+
+  const handleToggleGlobal = useCallback(
+    (actionId: ShortcutActionId, enabled: boolean) => {
+      updateShortcuts(draft => {
+        const entry = draft[actionId];
+        entry.global = {
+          ...(entry.global || { key: null, enabled: false }),
+          enabled,
+        };
+      });
+    },
+    [updateShortcuts],
+  );
+
+  useEffect(() => {
+    if (!capturing) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === 'Escape') {
+        setCapturing(null);
+        setCaptureError(null);
+        return;
+      }
+      const shortcutValue = eventToShortcut(event);
+      if (!shortcutValue) {
+        setCaptureError('Please include a non-modifier key in the shortcut.');
+        return;
+      }
+      updateShortcuts(draft => {
+        const entry = draft[capturing.actionId];
+        if (capturing.scope === 'app') {
+          entry.app = shortcutValue;
+        } else {
+          entry.global = {
+            ...(entry.global || { enabled: true, key: null }),
+            key: shortcutValue,
+            enabled: true,
+          };
+        }
+      });
+      setCapturing(null);
+      setCaptureError(null);
+    };
+
+    const handleBlur = () => {
+      setCapturing(null);
+      setCaptureError(null);
+    };
+
+    window.addEventListener('keydown', handleKeyDown, true);
+    window.addEventListener('blur', handleBlur);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, true);
+      window.removeEventListener('blur', handleBlur);
+    };
+  }, [capturing, updateShortcuts]);
+
+  const renderActionRow = (actionId: ShortcutActionId) => {
+    const definition = SHORTCUT_DEFINITION_MAP[actionId];
+    const entry = shortcuts[actionId];
+    const appConflict = appConflicts.get(actionId);
+    const globalConflict = globalConflicts.get(actionId);
+    const globalEnabled = entry.global?.enabled ?? false;
+    const cardHasConflict = Boolean(appConflict || globalConflict);
+
+    return (
+      <div
+        key={actionId}
+        className={`rounded-[--border-radius] border p-4 bg-[--bg-primary] transition-colors ${
+          cardHasConflict ? 'border-red-500/60 shadow-[0_0_0_1px_rgba(239,68,68,0.4)]' : 'border-[--border-secondary]'
+        }`}
+      >
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <h4 className="text-lg font-semibold text-[--text-primary]">{definition.label}</h4>
+              {definition.supportsGlobal && (
+                <span className="px-2 py-0.5 text-xs rounded-full bg-[--accent-settings]/10 text-[--accent-settings] border border-[--accent-settings]/30">
+                  Global available
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-[--text-muted] max-w-2xl">{definition.description}</p>
+            <div className="space-y-1">
+              {appConflict && <ConflictMessage scopeLabel="In-app" conflicts={appConflict.with} />}
+              {globalConflict && <ConflictMessage scopeLabel="Global" conflicts={globalConflict.with} />}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => handleResetAction(actionId)}
+              className="px-3 py-1.5 text-xs font-semibold rounded-lg border border-[--border-secondary] text-[--text-muted] hover:text-[--text-primary] hover:border-[--border-focus]"
+            >
+              Reset to default
+            </button>
+          </div>
+        </div>
+        <div className={`mt-4 grid gap-4 ${definition.supportsGlobal ? 'md:grid-cols-2' : 'grid-cols-1'}`}>
+          <ShortcutButton
+            label="In-App"
+            value={entry.app ?? null}
+            onClick={() => handleCaptureStart(actionId, 'app')}
+            onClear={() => handleClearShortcut(actionId, 'app')}
+            isCapturing={capturing?.actionId === actionId && capturing.scope === 'app'}
+            conflict={Boolean(appConflict)}
+          />
+          {definition.supportsGlobal && (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium uppercase tracking-wide text-[--text-muted]">Global</span>
+                <label className="flex items-center gap-2 text-xs font-medium text-[--text-muted]">
+                  <input
+                    type="checkbox"
+                    className="w-4 h-4 rounded border-[--border-secondary] text-[--accent-settings]"
+                    checked={globalEnabled}
+                    onChange={e => handleToggleGlobal(actionId, e.target.checked)}
+                  />
+                  Enable
+                </label>
+              </div>
+              <ShortcutButton
+                label="Shortcut"
+                value={entry.global?.key ?? null}
+                onClick={() => handleCaptureStart(actionId, 'global')}
+                onClear={() => handleClearShortcut(actionId, 'global')}
+                isCapturing={capturing?.actionId === actionId && capturing.scope === 'global'}
+                conflict={Boolean(globalConflict)}
+                disabled={!globalEnabled}
+              />
+              {!isElectron && (
+                <p className="text-xs text-[--text-muted]">Global shortcuts require the desktop app to take effect.</p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-[--text-primary]">Keyboard Shortcuts</h2>
+          <p className="text-sm text-[--text-muted]">
+            Customize the keyboard shortcuts used throughout the application. Conflicts are highlighted automatically.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRestoreDefaults}
+          className="self-start md:self-auto px-4 py-2 text-sm font-semibold rounded-lg bg-[--accent-settings] text-white hover:opacity-90"
+        >
+          Restore defaults
+        </button>
+      </div>
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <input
+          type="search"
+          value={searchTerm}
+          onChange={e => setSearchTerm(e.target.value)}
+          placeholder="Search by action, shortcut, or category…"
+          className="w-full md:max-w-sm px-4 py-2 rounded-lg border border-[--border-secondary] bg-[--bg-secondary] text-[--text-primary] focus:outline-none focus:ring-2 focus:ring-[--border-focus]"
+        />
+        {captureError && <p className="text-xs text-red-400 font-medium">{captureError}</p>}
+      </div>
+      {groupedDefinitions.length === 0 ? (
+        <div className="rounded-[--border-radius] border border-[--border-secondary] bg-[--bg-secondary] p-6 text-center text-[--text-muted]">
+          No shortcuts match your search.
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {groupedDefinitions.map(({ category, definitions }) => {
+            const label = SHORTCUT_CATEGORY_LABELS[category as keyof typeof SHORTCUT_CATEGORY_LABELS] || category;
+            const isExpanded = expandedCategories[category] ?? true;
+            return (
+              <div key={category} className="border border-[--border-primary] rounded-[--border-radius] overflow-hidden bg-[--bg-primary] shadow-sm">
+                <ShortcutHeader
+                  category={label}
+                  isExpanded={isExpanded}
+                  onToggle={() => handleToggleCategory(category)}
+                />
+                {isExpanded && (
+                  <div className="p-4 space-y-4">
+                    {definitions.map(def => renderActionRow(def.id))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default KeyboardShortcutsEditor;

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -10,14 +10,15 @@ import { useToast } from '../hooks/useToast';
 import KeyboardShortcutsEditor from './KeyboardShortcutsEditor';
 import { ensureShortcutSettings, getDefaultShortcutSettings } from '../shortcuts';
 
+export type SettingsSection = 'general' | 'personalization' | 'content' | 'shortcuts' | 'advanced';
+
 interface SettingsPanelProps {
   config: Config;
   onConfigChange: (newConfig: Config) => void;
   isElectron: boolean;
   theme: Theme;
+  initialSection?: SettingsSection | null;
 }
-
-type SettingsSection = 'general' | 'personalization' | 'content' | 'shortcuts' | 'advanced';
 
 const PREDEFINED_COLORS = [
   // Grayscale
@@ -266,12 +267,12 @@ const StatusIndicator: React.FC<{ status: 'online' | 'offline' | 'checking' | 'u
 };
 
 
-const SettingsPanel: React.FC<SettingsPanelProps> = ({ config, onConfigChange, isElectron, theme }) => {
+const SettingsPanel: React.FC<SettingsPanelProps> = ({ config, onConfigChange, isElectron, theme, initialSection }) => {
   const [localConfig, setLocalConfig] = useState<Config>({ ...config, shortcuts: ensureShortcutSettings(config.shortcuts) });
   const [activeAppearanceTab, setActiveAppearanceTab] = useState<Theme>(theme);
   const [toolchains, setToolchains] = useState<ToolchainStatus | null>(null);
   const [isLoadingTools, setIsLoadingTools] = useState(false);
-  const [activeSection, setActiveSection] = useState<SettingsSection>('general');
+  const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection ?? 'general');
   const [editingProvider, setEditingProvider] = useState<LLMProviderConfig | null>(null);
   const [isAddingProvider, setIsAddingProvider] = useState(false);
   const [providerStatuses, setProviderStatuses] = useState<Record<string, 'online' | 'offline' | 'checking' | 'unknown'>>({});
@@ -280,6 +281,12 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ config, onConfigChange, i
   const [jsonError, setJsonError] = useState<string | null>(null);
   const [isCheckingForUpdates, setIsCheckingForUpdates] = useState(false);
   const { addToast } = useToast();
+
+  useEffect(() => {
+    if (initialSection && initialSection !== activeSection) {
+      setActiveSection(initialSection);
+    }
+  }, [initialSection, activeSection]);
 
   // Refs for the new JSON editor implementation
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -595,6 +602,23 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ config, onConfigChange, i
           case 'general':
               return (
                 <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+                  <div className="xl:col-span-2 bg-[--bg-primary] border border-[--border-primary] rounded-[--border-radius] shadow-sm p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                    <div>
+                      <h3 className="text-xl font-semibold text-[--text-secondary]">Keyboard Shortcuts</h3>
+                      <p className="text-sm text-[--text-muted] mt-1 max-w-xl">
+                        Customize shortcuts for every action, manage global accelerators, and resolve conflicts in one dedicated editor.
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <button
+                        type="button"
+                        onClick={() => setActiveSection('shortcuts')}
+                        className="px-4 py-2 text-sm font-medium text-white bg-[--accent-settings] rounded-lg shadow hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[--accent-settings]"
+                      >
+                        Open Keyboard Shortcut Editor
+                      </button>
+                    </div>
+                  </div>
                   {(editingProvider || isAddingProvider) && (
                     <ProviderEditorModal
                       provider={editingProvider}

--- a/docs/keyboard-shortcut-editor-spec.md
+++ b/docs/keyboard-shortcut-editor-spec.md
@@ -1,0 +1,157 @@
+# Keyboard Shortcut Editor Specification
+
+## 1. Overview
+The keyboard shortcut editor provides a unified, accessible interface for customizing all keyboard commands in the application. It lives inside the Settings pane under the "Keyboard & Shortcuts" section and uses the same modern aesthetic as the rest of the app: generous white space, subtle elevation, rounded corners, and typographic hierarchy for clarity. The editor supports both application-specific and optional global shortcuts, gives real-time feedback on conflicts, and allows power users to manage large shortcut catalogs efficiently.
+
+## 2. Design Goals
+- **Discoverability:** Make it easy to find shortcuts by category, action name, or key combo.
+- **Consistency:** Align with the app's design system, including color, spacing, icons, and typography.
+- **Accessibility:** Fully navigable via keyboard, compatible with screen readers, and compliant with WCAG 2.1 AA contrast and focus requirements.
+- **Safety:** Prevent conflicting shortcuts through proactive validation and suggestions.
+- **Scalability:** Handle dozens of categories and hundreds of actions without performance degradation.
+
+## 3. Information Architecture
+### 3.1 Settings Integration
+- The Settings pane uses a left-aligned navigation sidebar. Add a **Keyboard & Shortcuts** entry that routes to the editor.
+- Retain existing breadcrumbs and search so users can jump directly to the editor.
+- Provide a "Restore defaults" button in the Settings header to reset all shortcuts after a confirmation dialog.
+
+### 3.2 Hierarchical Organization
+- **Top-level split:** Tabs or toggle buttons for **App Shortcuts** and **Global Shortcuts**. Tabs follow the app's segmented control component.
+- **Within each tab:** Vertical accordion of categories (e.g., Navigation, Editing, View Controls, AI Tools). Each accordion section contains a table-like list of actions and their assigned shortcuts.
+- **Action rows:** Display action name, current shortcut, scope badge (for context-sensitive actions), and an overflow menu for additional actions (reset, duplicate to other scope, view conflicts).
+- Provide a **Search bar** with instant filtering by action name, shortcut, or category.
+
+## 4. User Interface Details
+### 4.1 Layout
+- **Header:** Title, short description, "Restore defaults" button, and help icon linking to documentation.
+- **Tab bar:** Two segments (App / Global). Tab switch preserves scroll position per tab.
+- **Body:** Two-column responsive layout. On large screens, categories are listed in a left column with sticky headers; action tables appear on the right. On narrow screens (<960px), collapse to single-column stacked accordions.
+- **Action table row structure:**
+  - Left: Action title (16px semibold) with optional secondary description (12px regular) for tooltips or contextual hints.
+  - Center: Current shortcut pill button. When focused or clicked, enters "capture mode".
+  - Right: Conflict indicator (icon + tooltip) and overflow menu (three-dot button).
+- **Shortcut pill states:**
+  - Default: neutral background, key labels separated by plus signs.
+  - Hover/focus: highlight ring following design tokens.
+  - Capture mode: glowing border, placeholder text "Press new shortcut…"; cancel via Esc or clicking away.
+  - Invalid: red border and message below row explaining issue.
+
+### 4.2 Capture Modal (Optional)
+- For complex shortcuts, allow expanding to a modal providing advanced options (e.g., sequence shortcuts). Modal inherits focus trap and accessible labeling.
+
+### 4.3 Conflict Highlighting
+- Conflicts display as inline alerts under the affected action row with a red icon, textual description, and CTA buttons: **View conflicting action** (scrolls into view) and **Replace existing** (if user chooses to override).
+- Global vs App precedence is visually indicated using colored badges. If a global shortcut conflicts with an app-specific one, highlight both and explain which takes priority.
+
+### 4.4 Keyboard Navigation
+- Tab order: Settings navigation → header actions → tabs → search → category accordion → action rows.
+- Shortcut pills support `Enter` or `Space` to enter capture mode, `Esc` to cancel, arrow keys to move between actions.
+- Provide skip links (hidden by default) to jump between categories.
+
+### 4.5 Screen Reader Support
+- Use ARIA roles (`tablist`, `tab`, `tabpanel`, `button`, `alert`) as appropriate.
+- Announce capture mode instructions via `aria-live` region.
+- When conflicts occur, announce them using polite `aria-live` updates.
+
+## 5. Interaction Flow
+1. User opens Settings → Keyboard & Shortcuts.
+2. Default view shows App Shortcuts tab with categories collapsed except the first.
+3. User can search or browse categories; clicking an action's shortcut pill enters capture mode.
+4. In capture mode, the system listens for key combinations. Display real-time detection (e.g., "Ctrl" appears as soon as it is pressed) and validate on release.
+5. If the new shortcut is valid and conflict-free, save immediately, update the pill, and show "Saved" toast.
+6. If conflicts exist, show inline alert and disable auto-save. Provide options: cancel, override conflicting assignment, or open conflict resolution modal showing affected actions.
+7. For global shortcuts, allow toggling whether the shortcut is active while app is in focus or system-wide. If system-wide, request OS permissions when necessary.
+8. Changes persist instantly via state store; "Restore defaults" triggers confirmation dialog then resets all values, with undo toast available for 10 seconds.
+
+## 6. Technical Implementation
+### 6.1 Stack Alignment
+- Frontend uses React + TypeScript with Zustand (existing pattern) for state management.
+- Reuse design system components (Tabs, Accordion, Table, Toast, Tooltip, Dialog).
+- Keyboard event handling uses a custom hook (`useShortcutCapture`) to manage capture mode.
+
+### 6.2 Data Model
+```ts
+interface ShortcutAction {
+  id: string;
+  name: string;
+  description?: string;
+  categoryId: string;
+  defaultBinding: KeyBinding;
+  binding: KeyBinding | null;
+  scopes: Scope[]; // e.g., ["editor", "global"]
+}
+
+interface KeyBinding {
+  keys: string[]; // ordered key codes ("Ctrl", "Shift", "K")
+  sequence?: KeyBinding[]; // for multi-step combos
+  isGlobal: boolean;
+}
+
+interface Category {
+  id: string;
+  name: string;
+  description?: string;
+  order: number;
+}
+```
+
+### 6.3 State Management
+- Store categories, actions, and bindings in Zustand store (`useShortcutStore`).
+- Store also tracks UI state: activeTab, expandedCategories, searchQuery, captureState, conflictState.
+- Persist custom shortcuts via existing settings persistence service (local JSON / IPC to Electron main process).
+- Provide selectors for derived data (filtered actions, conflict map).
+
+### 6.4 Conflict Detection Algorithm
+1. Normalize all bindings to canonical string representations (e.g., `ctrl+shift+k`).
+2. Maintain a map `{scope: {bindingKey: actionId}}` to track assignments.
+3. When capturing a new binding:
+   - Check validity (no forbidden combos, required modifier rules per platform).
+   - Check map for existing assignments within the same scope (App or Global) and across scopes if `isGlobal`.
+   - If conflict found, populate `conflictState` with details: conflicting action IDs, scopes, severity.
+   - Provide recommended resolutions:
+     - Replace existing binding (updates conflicting action with null binding and assigns new one).
+     - Assign secondary binding if allowed (actions may support multiple bindings).
+     - Cancel capture.
+
+### 6.5 Real-time Updates
+- Shortcut pill updates immediately when `binding` changes in store.
+- Conflict alerts subscribe to `conflictState` and render conditionally.
+- Toast notifications triggered by store actions (e.g., `setBinding`, `restoreDefaults`).
+- Settings persistence uses debounced saving (e.g., 500ms) to avoid frequent disk writes.
+- Global shortcuts require bridging to Electron main process: send IPC message with updated global bindings; main process updates system-level listeners via `globalShortcut` API and returns success/failure.
+
+### 6.6 Undo & Versioning
+- Store maintains history stack (limited size) capturing previous state snapshots for undo/redo.
+- Undo triggered from toast or `Ctrl+Z` within settings; redo with `Ctrl+Y`.
+
+## 7. Conflict Resolution UI
+- Inline alert summarizing conflict and offering quick resolution buttons.
+- Dedicated dialog accessible from alert or overflow menu showing:
+  - Table of conflicting shortcuts with columns: Action, Scope, Current Binding, Priority.
+  - Radio buttons to choose resolution strategy (keep current, replace, clear other binding).
+  - Confirmation actions `Apply` and `Cancel`.
+
+## 8. Accessibility Considerations
+- Minimum touch target size 44x44px for interactive elements.
+- Focus states must meet 3:1 contrast ratio. Provide visible focus ring on all interactive components.
+- Ensure live regions do not interrupt other screen reader output (`aria-live="polite"`).
+- Provide textual description for icons via `aria-label` or `aria-describedby`.
+- Support High Contrast mode by avoiding reliance on color alone for conflict states (use icons and text).
+
+## 9. Localization & Internationalization
+- All text strings must be externalized via translation files.
+- Shortcut display adapts to platform-specific key names (e.g., `Cmd` on macOS, `Ctrl` on Windows/Linux).
+- Consider RTL layout: tabs and accordions reverse order; ensure mirrored icons.
+
+## 10. Testing Strategy
+- **Unit tests:** conflict detection reducer, normalization helpers, state selectors.
+- **Integration tests:** capturing shortcuts, resolving conflicts, restoring defaults.
+- **End-to-end tests:** using Playwright to simulate keyboard input, verifying focus management and screen reader attributes via accessibility tree snapshots.
+- **Accessibility audits:** Automated (axe-core) and manual screen reader testing.
+
+## 11. Open Questions
+- Determine maximum number of alternate bindings per action (default 2?).
+- Clarify OS-level permissions workflow for registering global shortcuts on macOS.
+- Define server sync requirements if shortcuts should persist across devices.
+

--- a/electron.d.ts
+++ b/electron.d.ts
@@ -1,4 +1,4 @@
-import type { Config, LogEntry, CodeProject, ProjectType, FileSystemEntry, ApiRequest, ApiResponse, ToolchainStatus } from './types';
+import type { Config, LogEntry, CodeProject, ProjectType, FileSystemEntry, ApiRequest, ApiResponse, ToolchainStatus, GlobalShortcutRegistrationInput, GlobalShortcutRegistrationResult, ShortcutActionId } from './types';
 
 export interface SystemStats {
   cpu: number;
@@ -12,6 +12,7 @@ export interface SystemStats {
 export interface IElectronAPI {
   getSettings: () => Promise<Config | null>;
   saveSettings: (settings: Config) => Promise<void>;
+  registerGlobalShortcuts: (shortcuts: GlobalShortcutRegistrationInput[]) => Promise<GlobalShortcutRegistrationResult[]>;
   isPackaged: () => Promise<boolean>;
   getVersion: () => Promise<string>;
   runPython: (code: string) => Promise<{ stdout: string; stderr: string }>;
@@ -70,6 +71,8 @@ export interface IElectronAPI {
   closeWindow: () => Promise<void>;
   onWindowStateChange: (callback: (isMaximized: boolean) => void) => void;
   removeWindowStateChangeListener: () => void;
+  onShortcutTriggered: (callback: (actionId: ShortcutActionId) => void) => void;
+  removeShortcutTriggeredListener: () => void;
 }
 
 declare global {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,7 +2,7 @@
 
 // FIX: Changed from destructured import to namespace import to resolve module access errors.
 import * as electron from 'electron';
-import type { CodeProject } from '../src/types';
+import type { CodeProject, GlobalShortcutRegistrationInput, ShortcutActionId } from '../src/types';
 
 /**
  * Expose protected methods that allow the renderer process to use
@@ -21,6 +21,10 @@ electron.contextBridge.exposeInMainWorld('electronAPI', {
    * @returns {Promise<void>} A promise that resolves when the settings are saved.
    */
   saveSettings: (settings: object) => electron.ipcRenderer.invoke('settings:save', settings),
+
+  registerGlobalShortcuts: (shortcuts: GlobalShortcutRegistrationInput[]) => electron.ipcRenderer.invoke('shortcuts:register-global', shortcuts),
+  onShortcutTriggered: (callback: (actionId: ShortcutActionId) => void) => electron.ipcRenderer.on('shortcuts:trigger', (_event, actionId) => callback(actionId)),
+  removeShortcutTriggeredListener: () => electron.ipcRenderer.removeAllListeners('shortcuts:trigger'),
 
   /**
    * Checks if the application is running in a packaged state.

--- a/shortcuts.ts
+++ b/shortcuts.ts
@@ -1,0 +1,389 @@
+import type {
+  ShortcutActionDefinition,
+  ShortcutActionId,
+  ShortcutAssignment,
+  ShortcutCategory,
+  ShortcutScope,
+  ShortcutSettings,
+  GlobalShortcutRegistrationInput,
+} from './types';
+
+const isMac = (() => {
+  if (typeof navigator !== 'undefined') {
+    return /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+  }
+  if (typeof process !== 'undefined') {
+    return process.platform === 'darwin';
+  }
+  return false;
+})();
+
+const MOD_KEY = isMac ? 'Meta' : 'Ctrl';
+
+const definitions: ShortcutActionDefinition[] = [
+  {
+    id: 'toggleCommandPalette',
+    label: 'Toggle Command Palette',
+    description: 'Open or close the universal command palette.',
+    category: 'navigation',
+    supportsGlobal: true,
+    defaultApp: `${MOD_KEY}+K`,
+    defaultGlobal: null,
+    defaultGlobalEnabled: false,
+    allowWhenTyping: false,
+    order: 1,
+  },
+  {
+    id: 'openSettings',
+    label: 'Open Settings',
+    description: 'Jump directly to the settings view.',
+    category: 'navigation',
+    supportsGlobal: false,
+    defaultApp: `${MOD_KEY}+,`,
+    order: 2,
+  },
+  {
+    id: 'startNewChat',
+    label: 'Start New Chat',
+    description: 'Create a fresh chat session.',
+    category: 'chat',
+    supportsGlobal: false,
+    defaultApp: `${MOD_KEY}+N`,
+    order: 1,
+  },
+  {
+    id: 'focusChatInput',
+    label: 'Focus Chat Input',
+    description: 'Move focus to the message composer.',
+    category: 'chat',
+    supportsGlobal: false,
+    defaultApp: `${MOD_KEY}+Shift+I`,
+    allowWhenTyping: true,
+    order: 2,
+  },
+  {
+    id: 'toggleLogsPanel',
+    label: 'Toggle Logs Panel',
+    description: 'Show or hide the diagnostic logs panel.',
+    category: 'system',
+    supportsGlobal: false,
+    defaultApp: `${MOD_KEY}+Shift+L`,
+    order: 3,
+  },
+  {
+    id: 'toggleTheme',
+    label: 'Toggle Theme',
+    description: 'Switch between light and dark mode.',
+    category: 'system',
+    supportsGlobal: false,
+    defaultApp: `${MOD_KEY}+Shift+T`,
+    order: 2,
+  },
+  {
+    id: 'showChatView',
+    label: 'Go to Chat',
+    description: 'Navigate to the chat workspace.',
+    category: 'views',
+    supportsGlobal: true,
+    defaultApp: `${MOD_KEY}+1`,
+    defaultGlobal: null,
+    order: 1,
+  },
+  {
+    id: 'showProjectsView',
+    label: 'Go to Projects',
+    description: 'Open the projects dashboard.',
+    category: 'views',
+    supportsGlobal: true,
+    defaultApp: `${MOD_KEY}+2`,
+    defaultGlobal: null,
+    order: 2,
+  },
+  {
+    id: 'showApiView',
+    label: 'Go to API Playground',
+    description: 'Switch to the API experimentation view.',
+    category: 'views',
+    supportsGlobal: false,
+    defaultApp: `${MOD_KEY}+3`,
+    order: 3,
+  },
+  {
+    id: 'showInfoView',
+    label: 'Show System Info',
+    description: 'Open the system information dashboard.',
+    category: 'views',
+    supportsGlobal: false,
+    defaultApp: `${MOD_KEY}+4`,
+    order: 4,
+  },
+];
+
+export const SHORTCUT_DEFINITIONS = definitions;
+
+export const SHORTCUT_DEFINITION_MAP: Record<ShortcutActionId, ShortcutActionDefinition> = definitions.reduce(
+  (acc, def) => {
+    acc[def.id] = def;
+    return acc;
+  },
+  {} as Record<ShortcutActionId, ShortcutActionDefinition>,
+);
+
+export const SHORTCUT_CATEGORY_ORDER: Record<ShortcutCategory, number> = {
+  navigation: 1,
+  chat: 2,
+  views: 3,
+  system: 4,
+};
+
+export const SHORTCUT_CATEGORY_LABELS: Record<ShortcutCategory, string> = {
+  navigation: 'Navigation',
+  chat: 'Chat & Composition',
+  views: 'Views',
+  system: 'System',
+};
+
+export const SHORTCUT_MODIFIER_ORDER = ['Ctrl', 'Meta', 'Alt', 'Shift'] as const;
+
+export function cloneShortcutSettings(settings: ShortcutSettings): ShortcutSettings {
+  const clone: Partial<ShortcutSettings> = {};
+  (Object.keys(settings) as ShortcutActionId[]).forEach(actionId => {
+    const entry = settings[actionId];
+    clone[actionId] = {
+      app: entry.app ?? null,
+      global: entry.global ? { ...entry.global } : entry.global,
+    } as ShortcutAssignment;
+  });
+  return clone as ShortcutSettings;
+}
+
+export function getDefaultShortcutSettings(): ShortcutSettings {
+  const defaults: Partial<ShortcutSettings> = {};
+  definitions.forEach(def => {
+    defaults[def.id] = {
+      app: def.defaultApp ?? null,
+      global: def.supportsGlobal
+        ? {
+            key: def.defaultGlobal ?? null,
+            enabled: def.defaultGlobalEnabled ?? Boolean(def.defaultGlobal),
+          }
+        : undefined,
+    } as ShortcutAssignment;
+  });
+  return defaults as ShortcutSettings;
+}
+
+export function ensureShortcutSettings(settings?: ShortcutSettings): ShortcutSettings {
+  const base = getDefaultShortcutSettings();
+  if (!settings) {
+    return base;
+  }
+  const normalized = cloneShortcutSettings(base as ShortcutSettings);
+  (Object.keys(base) as ShortcutActionId[]).forEach(actionId => {
+    const existing = settings[actionId];
+    if (!existing) {
+      return;
+    }
+    const target = normalized[actionId];
+    if (existing.app !== undefined) {
+      target.app = existing.app ?? null;
+    }
+    if (target.global) {
+      const existingGlobal = existing.global;
+      target.global = {
+        key: existingGlobal?.key ?? target.global.key ?? null,
+        enabled:
+          existingGlobal?.enabled !== undefined
+            ? existingGlobal.enabled
+            : target.global.enabled,
+      };
+    }
+  });
+  return normalized;
+}
+
+function normalizeKeyLabel(key: string): string {
+  const upper = key.length === 1 ? key.toUpperCase() : key;
+  switch (upper) {
+    case 'CONTROL':
+    case 'CTRL':
+      return 'Ctrl';
+    case 'META':
+    case 'COMMAND':
+      return 'Meta';
+    case 'ALT':
+    case 'OPTION':
+      return 'Alt';
+    case 'SHIFT':
+      return 'Shift';
+    case 'ESC':
+    case 'ESCAPE':
+      return 'Escape';
+    case ' ': 
+      return 'Space';
+    default:
+      return upper.length === 1 ? upper : upper.charAt(0).toUpperCase() + upper.slice(1);
+  }
+}
+
+function sortShortcutParts(parts: string[]): string[] {
+  const modifiers = [] as string[];
+  const keys = [] as string[];
+  parts.forEach(part => {
+    if (SHORTCUT_MODIFIER_ORDER.includes(part as (typeof SHORTCUT_MODIFIER_ORDER)[number])) {
+      modifiers.push(part);
+    } else {
+      keys.push(part);
+    }
+  });
+  const sortedModifiers = modifiers.sort(
+    (a, b) => SHORTCUT_MODIFIER_ORDER.indexOf(a as any) - SHORTCUT_MODIFIER_ORDER.indexOf(b as any),
+  );
+  return [...sortedModifiers, ...keys];
+}
+
+export function eventToShortcut(event: KeyboardEvent): string | null {
+  const parts: string[] = [];
+  if (event.ctrlKey) parts.push('Ctrl');
+  if (event.metaKey) parts.push('Meta');
+  if (event.altKey) parts.push('Alt');
+  if (event.shiftKey) parts.push('Shift');
+
+  let keyLabel = event.key;
+  if (!keyLabel) {
+    return null;
+  }
+
+  keyLabel = normalizeKeyLabel(keyLabel);
+
+  const isModifierOnly = ['Ctrl', 'Meta', 'Alt', 'Shift'].includes(keyLabel);
+  if (isModifierOnly && parts.length === 0) {
+    return null;
+  }
+  if (!isModifierOnly) {
+    parts.push(keyLabel);
+  }
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  const normalized = sortShortcutParts(parts);
+  return normalized.join('+');
+}
+
+const DISPLAY_SYMBOLS: Record<string, string> = {
+  Meta: isMac ? '⌘' : 'Meta',
+  Ctrl: isMac ? '⌃' : 'Ctrl',
+  Alt: isMac ? '⌥' : 'Alt',
+  Shift: isMac ? '⇧' : 'Shift',
+};
+
+export function formatShortcut(shortcut: string | null): string {
+  if (!shortcut) return 'Not set';
+  return shortcut
+    .split('+')
+    .map(part => DISPLAY_SYMBOLS[part] || part)
+    .join(' + ');
+}
+
+export function getEffectiveShortcut(
+  settings: ShortcutSettings,
+  actionId: ShortcutActionId,
+  scope: ShortcutScope,
+): string | null {
+  const entry = settings[actionId];
+  if (!entry) return null;
+  if (scope === 'app') {
+    return entry.app ?? null;
+  }
+  return entry.global?.enabled ? entry.global.key ?? null : null;
+}
+
+export interface ShortcutConflictInfo {
+  key: string;
+  with: ShortcutActionId[];
+}
+
+export function findShortcutConflicts(
+  settings: ShortcutSettings,
+  scope: ShortcutScope,
+): Map<ShortcutActionId, ShortcutConflictInfo> {
+  const occurrences = new Map<string, ShortcutActionId[]>();
+  definitions.forEach(def => {
+    const key = getEffectiveShortcut(settings, def.id, scope);
+    if (!key) return;
+    const list = occurrences.get(key) ?? [];
+    list.push(def.id);
+    occurrences.set(key, list);
+  });
+
+  const conflicts = new Map<ShortcutActionId, ShortcutConflictInfo>();
+  occurrences.forEach((actionIds, key) => {
+    if (actionIds.length <= 1) return;
+    actionIds.forEach(actionId => {
+      conflicts.set(actionId, {
+        key,
+        with: actionIds.filter(id => id !== actionId),
+      });
+    });
+  });
+  return conflicts;
+}
+
+const ELECTRON_KEY_ALIASES: Record<string, string> = {
+  Ctrl: 'Control',
+  Meta: 'Command',
+  Escape: 'Escape',
+  Space: 'Space',
+};
+
+export function toElectronAccelerator(shortcut: string): string {
+  return shortcut
+    .split('+')
+    .map(part => ELECTRON_KEY_ALIASES[part] ?? part)
+    .join('+');
+}
+
+export function getGlobalShortcutRegistrations(
+  settings: ShortcutSettings,
+): GlobalShortcutRegistrationInput[] {
+  return definitions
+    .filter(def => def.supportsGlobal)
+    .map(def => {
+      const entry = settings[def.id];
+      const key = entry?.global?.key ?? null;
+      return {
+        actionId: def.id,
+        accelerator: key ? toElectronAccelerator(key) : '',
+        enabled: Boolean(entry?.global?.enabled && key),
+      };
+    });
+}
+
+export function getDefaultAssignment(actionId: ShortcutActionId): ShortcutAssignment {
+  return cloneShortcutSettings(getDefaultShortcutSettings())[actionId];
+}
+
+export function allowsTypingContext(actionId: ShortcutActionId): boolean {
+  return Boolean(SHORTCUT_DEFINITION_MAP[actionId]?.allowWhenTyping);
+}
+
+export function shortcutMatchesSearch(
+  definition: ShortcutActionDefinition,
+  shortcut: ShortcutAssignment,
+  term: string,
+): boolean {
+  if (!term) return true;
+  const haystack = [
+    definition.label,
+    definition.description,
+    definition.category,
+    shortcut.app ?? '',
+    shortcut.global?.key ?? '',
+  ]
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(term.toLowerCase());
+}
+

--- a/types.ts
+++ b/types.ts
@@ -79,6 +79,66 @@ export interface Config {
   selectedJavaPath?: string;
   selectedNodePath?: string;
   selectedDelphiPath?: string;
+  shortcuts?: ShortcutSettings;
+}
+
+// Keyboard Shortcuts
+export type ShortcutScope = 'app' | 'global';
+
+export type ShortcutCategory =
+  | 'navigation'
+  | 'chat'
+  | 'views'
+  | 'system';
+
+export type ShortcutActionId =
+  | 'toggleCommandPalette'
+  | 'startNewChat'
+  | 'focusChatInput'
+  | 'toggleLogsPanel'
+  | 'toggleTheme'
+  | 'openSettings'
+  | 'showChatView'
+  | 'showProjectsView'
+  | 'showApiView'
+  | 'showInfoView';
+
+export interface ShortcutGlobalBinding {
+  key: string | null;
+  enabled: boolean;
+}
+
+export interface ShortcutAssignment {
+  app: string | null;
+  global?: ShortcutGlobalBinding;
+}
+
+export type ShortcutSettings = Record<ShortcutActionId, ShortcutAssignment>;
+
+export interface ShortcutActionDefinition {
+  id: ShortcutActionId;
+  label: string;
+  description: string;
+  category: ShortcutCategory;
+  supportsGlobal: boolean;
+  defaultApp?: string | null;
+  defaultGlobal?: string | null;
+  defaultGlobalEnabled?: boolean;
+  allowWhenTyping?: boolean;
+  order: number;
+}
+
+export interface GlobalShortcutRegistrationInput {
+  actionId: ShortcutActionId;
+  accelerator: string;
+  enabled: boolean;
+}
+
+export interface GlobalShortcutRegistrationResult {
+  actionId: ShortcutActionId;
+  accelerator: string;
+  success: boolean;
+  error?: string;
 }
 
 // Language Model and Chat Types


### PR DESCRIPTION
## Summary
- add a settings section for managing keyboard shortcuts with capture UI, conflict detection, and search
- persist shortcut overrides, wire them into application actions, and register global accelerators through Electron
- expose new shortcut APIs, sanitize config loading, and support focusing the chat composer via shortcuts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd68480394833296188c2d0d80be8b