### PR TITLE
Add SVG-driven icon generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+build
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ To create a distributable executable, run:
 `npm run package`
 
 The output will be in the `release/` directory. The installer will place all necessary files, including this documentation, into the installation directory.
+
+### Application Icon
+
+- Place an SVG file (preferably named `icon.svg`) anywhere within the `assets/` directory tree.
+- Running `npm run build` automatically validates the SVG and generates platform-specific icon assets (`.icns`, `.ico`, and `.png`) under `build/icons/`.
+- If no SVG is found or the file is invalid, a fallback icon is generated so packaging can still proceed.

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#22d3ee"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#grad)"/>
+  <g fill="#ffffff" transform="translate(32,32)">
+    <path d="M24 0c13.255 0 24 10.745 24 24S37.255 48 24 48 0 37.255 0 24 10.745 0 24 0zm0 8c-8.836 0-16 7.164-16 16s7.164 16 16 16 16-7.164 16-16S32.836 8 24 8z" opacity="0.9"/>
+    <path d="M12 40h24l12 16H0z" opacity="0.9"/>
+  </g>
+</svg>

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,17 +1,164 @@
 const esbuild = require('esbuild');
 const fs = require('fs-extra');
 const path = require('path');
+const sharp = require('sharp');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const { appBuilderPath } = require('app-builder-bin');
+
+const execFileAsync = promisify(execFile);
 
 const isProduction = process.argv.includes('--production');
 
 // Source and output directories
 const appDir = __dirname;
 const outDir = path.join(__dirname, 'dist');
+const iconSourceDir = path.join(appDir, 'assets');
+const iconOutputDir = path.join(appDir, 'build', 'icons');
 const docFiles = ['README.md', 'FUNCTIONAL_MANUAL.md', 'TECHNICAL_MANUAL.md', 'CHANGELOG.md'];
+
+const DEFAULT_ICON_SVG = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="default-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e293b" />
+      <stop offset="100%" stop-color="#64748b" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#default-grad)" />
+  <g fill="#f8fafc" transform="translate(28,28)">
+    <path d="M72 12v48a12 12 0 0 1-12 12H12a12 12 0 0 1-12-12V24A12 12 0 0 1 12 12h48l12-12z" opacity="0.8" />
+    <circle cx="36" cy="36" r="14" opacity="0.9" />
+  </g>
+</svg>`;
+
+async function collectSvgFiles(dir, results = []) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectSvgFiles(fullPath, results);
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.svg')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+async function findSvgIcon(baseDir) {
+  if (!(await fs.pathExists(baseDir))) {
+    return null;
+  }
+  const svgFiles = await collectSvgFiles(baseDir);
+  if (svgFiles.length === 0) {
+    return null;
+  }
+  svgFiles.sort((a, b) => {
+    const aName = path.basename(a).toLowerCase();
+    const bName = path.basename(b).toLowerCase();
+    if (aName === 'icon.svg' && bName !== 'icon.svg') return -1;
+    if (bName === 'icon.svg' && aName !== 'icon.svg') return 1;
+    return a.localeCompare(b);
+  });
+  return svgFiles[0];
+}
+
+function isValidSvg(content) {
+  if (typeof content !== 'string') return false;
+  return /<svg[\s>]/i.test(content) && /<\/svg>/i.test(content);
+}
+
+async function renderSvgToPng(svgContent, size) {
+  return sharp(Buffer.from(svgContent)).resize(size, size, {
+    fit: 'contain',
+    background: { r: 0, g: 0, b: 0, alpha: 0 },
+  }).png().toBuffer();
+}
+
+async function generateNativeIcon(format, pngInputs, outputPath) {
+  if (!(fs.existsSync(appBuilderPath))) {
+    throw new Error(`app-builder binary not found at ${appBuilderPath}`);
+  }
+  const args = ['icon'];
+  for (const input of pngInputs) {
+    args.push('--input', input);
+  }
+  args.push('--format', format, '--out', outputPath);
+
+  await execFileAsync(appBuilderPath, args);
+}
+
+async function writePlatformIcons(svgContent, originDescription) {
+  await fs.ensureDir(iconOutputDir);
+  await fs.emptyDir(iconOutputDir);
+
+  const basePng = await renderSvgToPng(svgContent, 1024);
+  await fs.writeFile(path.join(iconOutputDir, 'icon-1024.png'), basePng);
+
+  const png512 = await sharp(basePng).resize(512, 512).png().toBuffer();
+  await fs.writeFile(path.join(iconOutputDir, 'icon.png'), png512);
+  await fs.writeFile(path.join(iconOutputDir, 'icon-512.png'), png512);
+
+  const png256 = await sharp(basePng).resize(256, 256).png().toBuffer();
+  await fs.writeFile(path.join(iconOutputDir, 'icon-256.png'), png256);
+
+  const pngInputs = [
+    path.join(iconOutputDir, 'icon-1024.png'),
+    path.join(iconOutputDir, 'icon-512.png'),
+    path.join(iconOutputDir, 'icon-256.png'),
+  ];
+
+  await generateNativeIcon('icns', pngInputs, path.join(iconOutputDir, 'icon.icns'));
+  await generateNativeIcon('ico', pngInputs, path.join(iconOutputDir, 'icon.ico'));
+
+  console.log(`[icon] Generated platform icons from ${originDescription}.`);
+}
+
+async function ensurePlatformIcons() {
+  let svgContent = DEFAULT_ICON_SVG;
+  let originDescription = 'built-in fallback icon';
+  let usingFallback = true;
+
+  try {
+    const svgPath = await findSvgIcon(iconSourceDir);
+    if (svgPath) {
+      const content = await fs.readFile(svgPath, 'utf8');
+      if (!isValidSvg(content)) {
+        throw new Error(`Invalid SVG structure detected at ${path.relative(appDir, svgPath)}`);
+      }
+      svgContent = content;
+      originDescription = path.relative(appDir, svgPath);
+      usingFallback = false;
+    } else {
+      console.warn('[icon] No SVG icon found in the assets directory; using fallback icon.');
+    }
+  } catch (error) {
+    console.warn(`[icon] ${error.message}. Falling back to the default icon.`);
+  }
+
+  try {
+    await writePlatformIcons(svgContent, originDescription);
+  } catch (error) {
+    if (!usingFallback) {
+      console.error(`[icon] Failed to generate icons from ${originDescription}: ${error.message}. Falling back to default icon.`);
+      try {
+        await writePlatformIcons(DEFAULT_ICON_SVG, 'built-in fallback icon');
+      } catch (fallbackError) {
+        console.error(`[icon] Failed to generate fallback icon set: ${fallbackError.message}`);
+      }
+    } else {
+      console.error(`[icon] Failed to generate icons from fallback SVG: ${error.message}`);
+    }
+  }
+}
 
 async function build() {
   // Clean the output directory
   await fs.emptyDir(outDir);
+
+  // Ensure platform-specific icons are generated from the SVG source.
+  await ensurePlatformIcons();
 
   // Copy index.html and documentation to the output directory
   await fs.copy(path.join(appDir, 'index.html'), path.join(outDir, 'index.html'));

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "electron-builder": "^24.13.3",
     "esbuild": "^0.23.0",
     "fs-extra": "^11.2.0",
+    "sharp": "^0.33.4",
     "typescript": "^5.5.3"
   },
   "build": {
@@ -56,8 +57,15 @@
       "owner": "beNative",
       "repo": "local-llm-interface"
     },
+    "mac": {
+      "icon": "build/icons/icon.icns"
+    },
     "win": {
-      "target": "nsis"
+      "target": "nsis",
+      "icon": "build/icons/icon.ico"
+    },
+    "linux": {
+      "icon": "build/icons/icon.png"
     },
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
## Summary
- extend the build script to locate SVG assets, validate them, and generate platform icon formats during `npm run build`
- configure electron-builder to use the generated icons and document the SVG workflow
- add a default SVG icon asset and ignore generated icon artifacts

## Testing
- npm install *(fails: registry returned 403 for sharp)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7b8b44008332990fffabace0a848