### PR TITLE
Fix Windows packaging icon generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "electron-builder": "^24.13.3",
     "esbuild": "^0.23.0",
     "fs-extra": "^11.2.0",
+    "png-to-ico": "^2.1.8",
     "sharp": "^0.33.4",
     "typescript": "^5.5.3"
   },


### PR DESCRIPTION
## Summary
- add png-to-ico to build tooling so Windows icon files are generated without relying on app-builder
- create additional PNG sizes and build the ICO via png-to-ico while keeping ICNS generation unchanged

## Testing
- not run (sharp dependency is not installed in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd7e40fe348332ae07832736065a10