### PR TITLE
Prepare 0.19.3 release documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.3] - 2025-10-06
+
+### Changed
+- Synchronized the release checklist and supporting manuals to call out preparing GitHub release notes alongside the Markdown
+  documentation audit.
+
+### Fixed
+- Refreshed documentation references so in-app manuals and examples reflect version 0.19.3 for the upcoming release.
+
 ## [0.19.2] - 2025-10-05
 
 ### Fixed

--- a/FUNCTIONAL_MANUAL.md
+++ b/FUNCTIONAL_MANUAL.md
@@ -103,7 +103,7 @@ The "API Client" is a new view designed for testing and interacting with HTTP AP
 The "Info" tab is your central hub for all application documentation and metadata.
 
 - **Documentation Viewer**: Read the `README`, `Functional Manual` (this document), `Technical Manual`, and `Changelog` directly within the app. This is useful for offline access and quick reference.
-- **Release Notes**: The changelog view now highlights the most recent version (e.g., 0.19.2) so you can quickly review what changed before updating.
+- **Release Notes**: The changelog view now highlights the most recent version (e.g., 0.19.3) so you can quickly review what changed before updating. Capture the same talking points while auditing documentation so the GitHub release draft mirrors the in-app notes.
 - **About Dialog**: At the bottom of the page, click the **"About This App"** link to open a dialog. This dialog displays the application's version, credits for design and implementation, and copyright information.
 
 ## 7. Model Selection

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Follow this checklist when preparing a new GitHub release:
    - Review `README.md`, the functional/technical manuals, and any docs under `docs/` for accuracy.
    - Ensure new features or workflow changes are reflected so in-app documentation is current.
    - Double-check version references across all Markdown files to match the release number and latest UI terminology.
+   - Capture the highlights for the GitHub release notes while you audit the documentation so the draft stays in sync with the
+     changelog.
 3. **Verify the Build**
    - Run `npm install` (if needed) and `npm run build` to ensure the project bundles without errors.
    - Optionally execute `npm run package` to validate installer creation locally before publishing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-llm-interface",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "local-llm-interface",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm-interface",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "An interface to chat with locally installed LLMs serviced through Ollama or LMStudio. This Electron app allows configuration of the service endpoint and provides an overview of available models.",
   "main": "dist/main.js",
   "author": "",


### PR DESCRIPTION
## Summary
- bump the application version to 0.19.3 for the upcoming patch release
- refresh release documentation to capture GitHub release note preparation alongside the Markdown audit
- update the changelog and manuals so in-app references point to the new version

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4dbdf7b24833292720aeccfdb338d