### PR TITLE
Add toggle for automatic update checks

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -364,6 +364,7 @@ const AppContent: React.FC = () => {
         },
         logToFile: false,
         allowPrerelease: false,
+        autoCheckForUpdates: true,
         pythonProjectsPath: '',
         nodejsProjectsPath: '',
         webAppsPath: '',

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -746,7 +746,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ config, onConfigChange, i
                         </div>
                          <div className="pt-6 border-t border-[--border-primary]">
                             <h3 className="text-xl font-semibold text-[--text-secondary] mb-4">Updates</h3>
-                             <div className="flex items-center gap-4">
+                             <div className="flex flex-wrap items-center gap-4">
                                 <button
                                     onClick={handleCheckForUpdates}
                                     disabled={isCheckingForUpdates}
@@ -764,8 +764,18 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ config, onConfigChange, i
                                     />
                                     <span className="text-sm font-medium text-[--text-muted]">Receive pre-release versions</span>
                                 </label>
+                                <label className="flex items-center gap-3 cursor-pointer">
+                                    <input
+                                        type="checkbox"
+                                        checked={localConfig.autoCheckForUpdates !== false}
+                                        onChange={(e) => handleSimpleConfigChange('autoCheckForUpdates', e.target.checked)}
+                                        className="w-4 h-4 rounded text-indigo-600 bg-[--bg-tertiary] border-[--border-secondary] focus:ring-indigo-500"
+                                    />
+                                    <span className="text-sm font-medium text-[--text-muted]">Check for updates automatically</span>
+                                </label>
                             </div>
                             <p className="text-xs text-[--text-muted] mt-2 px-1">Get early access to new features. Pre-releases may be unstable.</p>
+                            <p className="text-xs text-[--text-muted] mt-1 px-1">Disable automatic checks if you prefer to look for updates manually.</p>
                         </div>
                     </div>
                   )}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -709,6 +709,14 @@ electron.app.whenReady().then(() => {
             mainWindowInstance?.webContents.send('update-not-available', { version: electron.app.getVersion() });
             return;
         }
+        const settings = readSettings() as any;
+        if (settings && settings.allowPrerelease) {
+            autoUpdater.allowPrerelease = true;
+            console.log('Allowing pre-releases for auto-updater.');
+        } else {
+            autoUpdater.allowPrerelease = false;
+            console.log('Not allowing pre-releases for auto-updater.');
+        }
         hasSentDownloadingMessage = false;
         return autoUpdater.checkForUpdates();
     });
@@ -1169,8 +1177,14 @@ end.
         autoUpdater.allowPrerelease = false;
         console.log('Not allowing pre-releases for auto-updater.');
       }
-      hasSentDownloadingMessage = false;
-      autoUpdater.checkForUpdates();
+
+      const autoCheckEnabled = settings?.autoCheckForUpdates !== false;
+      if (autoCheckEnabled) {
+        hasSentDownloadingMessage = false;
+        autoUpdater.checkForUpdates();
+      } else {
+        console.log('Automatic update checks are disabled in settings.');
+      }
     }
 
     // Re-create a window on macOS when the dock icon is clicked and there are no other windows open.

--- a/types.ts
+++ b/types.ts
@@ -63,6 +63,7 @@ export interface Config {
   themeOverrides?: ThemeOverrides;
   logToFile?: boolean;
   allowPrerelease?: boolean;
+  autoCheckForUpdates?: boolean;
   pythonProjectsPath?: string;
   nodejsProjectsPath?: string;
   webAppsPath?: string;


### PR DESCRIPTION
## Summary
- add a persisted configuration flag to control automatic update checks
- expose the new toggle in the settings updates section with descriptive copy
- honor the toggle in the Electron startup flow while keeping manual checks available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fcfe642a108332862df0f8ccfe4fb5